### PR TITLE
Switch to FactLoaderModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3
+- Improved displaying progress.
+- Reset wifi creds on startup.
+
 ## v1.2
 - Improved memory allocation.
 - Added in Dog Facts.

--- a/alloc/flip_library_alloc.c
+++ b/alloc/flip_library_alloc.c
@@ -8,89 +8,83 @@ FlipLibraryApp *flip_library_app_alloc()
     Gui *gui = furi_record_open(RECORD_GUI);
 
     if (!flipper_http_init(flipper_http_rx_callback, app))
-    {
-        FURI_LOG_E(TAG, "Failed to initialize flipper http");
-        return NULL;
-    }
+        {
+            FURI_LOG_E(TAG, "Failed to initialize flipper http");
+            return NULL;
+        }
 
     // Allocate the text input buffer
     app->uart_text_input_buffer_size_ssid = 64;
     app->uart_text_input_buffer_size_password = 64;
-    app->uart_text_input_buffer_size_dictionary = 64;
+    app->uart_text_input_buffer_size_query = 64;
     if (!easy_flipper_set_buffer(&app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_size_ssid))
-    {
-        return NULL;
-    }
+        {
+            return NULL;
+        }
     if (!easy_flipper_set_buffer(&app->uart_text_input_temp_buffer_ssid, app->uart_text_input_buffer_size_ssid))
-    {
-        return NULL;
-    }
+        {
+            return NULL;
+        }
     if (!easy_flipper_set_buffer(&app->uart_text_input_buffer_password, app->uart_text_input_buffer_size_password))
-    {
-        return NULL;
-    }
+        {
+            return NULL;
+        }
     if (!easy_flipper_set_buffer(&app->uart_text_input_temp_buffer_password, app->uart_text_input_buffer_size_password))
-    {
-        return NULL;
-    }
-    if (!easy_flipper_set_buffer(&app->uart_text_input_buffer_dictionary, app->uart_text_input_buffer_size_dictionary))
-    {
-        return NULL;
-    }
-    if (!easy_flipper_set_buffer(&app->uart_text_input_temp_buffer_dictionary, app->uart_text_input_buffer_size_dictionary))
-    {
-        return NULL;
-    }
+        {
+            return NULL;
+        }
+    if (!easy_flipper_set_buffer(&app->uart_text_input_buffer_query, app->uart_text_input_buffer_size_query))
+        {
+            return NULL;
+        }
+    if (!easy_flipper_set_buffer(&app->uart_text_input_temp_buffer_query, app->uart_text_input_buffer_size_query))
+        {
+            return NULL;
+        }
 
     // Allocate ViewDispatcher
     if (!easy_flipper_set_view_dispatcher(&app->view_dispatcher, gui, app))
-    {
-        return NULL;
-    }
+        {
+            return NULL;
+        }
+    view_dispatcher_set_custom_event_callback(app->view_dispatcher, flip_library_custom_event_callback);
 
     // Main view
-    if (!easy_flipper_set_view(&app->view_random_facts, FlipLibraryViewRandomFactsRun, view_draw_callback_random_facts, NULL, callback_to_random_facts, &app->view_dispatcher, app))
-    {
-        return NULL;
-    }
-    if (!easy_flipper_set_view(&app->view_dictionary, FlipLibraryViewDictionaryRun, view_draw_callback_dictionary_run, NULL, callback_to_submenu, &app->view_dispatcher, app))
-    {
-        return NULL;
-    }
+    if (!easy_flipper_set_view(&app->view_loader, FlipLibraryViewLoader, flip_library_loader_draw_callback, NULL, callback_to_random_facts, &app->view_dispatcher, app))
+        {
+            return NULL;
+        }
+    flip_library_loader_init(app->view_loader);
 
     // Widget
-    if (!easy_flipper_set_widget(&app->widget, FlipLibraryViewAbout, "FlipLibrary v1.2\n-----\nDictionary, random facts, and\nmore.\n-----\nwww.github.com/jblanked", callback_to_submenu, &app->view_dispatcher))
-    {
-        return NULL;
-    }
-    if (!easy_flipper_set_widget(&app->widget_random_fact, FlipLibraryViewRandomFactWidget, "Error, try again.", callback_to_random_facts, &app->view_dispatcher))
-    {
-        return NULL;
-    }
-    if (!easy_flipper_set_widget(&app->widget_dictionary, FlipLibraryViewDictionaryWidget, "Error, try again.", callback_to_submenu, &app->view_dispatcher))
-    {
-        return NULL;
-    }
+    if (!easy_flipper_set_widget(&app->widget_about, FlipLibraryViewAbout, "FlipLibrary v1.3\n-----\nDictionary, random facts, and\nmore.\n-----\nwww.github.com/jblanked", callback_to_submenu, &app->view_dispatcher))
+        {
+            return NULL;
+        }
+    if (!easy_flipper_set_widget(&app->widget_result, FlipLibraryViewWidgetResult, "Error, try again.", callback_to_random_facts, &app->view_dispatcher))
+        {
+            return NULL;
+        }
 
     // Text Input
     if (!easy_flipper_set_uart_text_input(&app->uart_text_input_ssid, FlipLibraryViewTextInputSSID, "Enter SSID", app->uart_text_input_temp_buffer_ssid, app->uart_text_input_buffer_size_ssid, text_updated_ssid, callback_to_wifi_settings, &app->view_dispatcher, app))
-    {
-        return NULL;
-    }
+        {
+            return NULL;
+        }
     if (!easy_flipper_set_uart_text_input(&app->uart_text_input_password, FlipLibraryViewTextInputPassword, "Enter Password", app->uart_text_input_temp_buffer_password, app->uart_text_input_buffer_size_password, text_updated_password, callback_to_wifi_settings, &app->view_dispatcher, app))
-    {
-        return NULL;
-    }
-    if (!easy_flipper_set_uart_text_input(&app->uart_text_input_dictionary, FlipLibraryViewDictionaryTextInput, "Enter a word", app->uart_text_input_temp_buffer_dictionary, app->uart_text_input_buffer_size_dictionary, text_updated_dictionary, callback_to_submenu, &app->view_dispatcher, app))
-    {
-        return NULL;
-    }
+        {
+            return NULL;
+        }
+    if (!easy_flipper_set_uart_text_input(&app->uart_text_input_query, FlipLibraryViewTextInputQuery, "Enter Query", app->uart_text_input_temp_buffer_query, app->uart_text_input_buffer_size_query, text_updated_query, callback_to_submenu, &app->view_dispatcher, app))
+        {
+            return NULL;
+        }
 
     // Variable Item List
     if (!easy_flipper_set_variable_item_list(&app->variable_item_list_wifi, FlipLibraryViewSettings, settings_item_selected, callback_to_submenu, &app->view_dispatcher, app))
-    {
-        return NULL;
-    }
+        {
+            return NULL;
+        }
 
     app->variable_item_ssid = variable_item_list_add(app->variable_item_list_wifi, "SSID", 0, NULL, NULL);
     app->variable_item_password = variable_item_list_add(app->variable_item_list_wifi, "Password", 0, NULL, NULL);
@@ -98,14 +92,14 @@ FlipLibraryApp *flip_library_app_alloc()
     variable_item_set_current_value_text(app->variable_item_password, "");
 
     // Submenu
-    if (!easy_flipper_set_submenu(&app->submenu_main, FlipLibraryViewSubmenuMain, "FlipLibrary v1.2", callback_exit_app, &app->view_dispatcher))
-    {
-        return NULL;
-    }
+    if (!easy_flipper_set_submenu(&app->submenu_main, FlipLibraryViewSubmenuMain, "FlipLibrary v1.3", callback_exit_app, &app->view_dispatcher))
+        {
+            return NULL;
+        }
     if (!easy_flipper_set_submenu(&app->submenu_random_facts, FlipLibraryViewRandomFacts, "Random Facts", callback_to_submenu, &app->view_dispatcher))
-    {
-        return NULL;
-    }
+        {
+            return NULL;
+        }
 
     submenu_add_item(app->submenu_main, "Random Fact", FlipLibrarySubmenuIndexRandomFacts, callback_submenu_choices, app);
     submenu_add_item(app->submenu_main, "Dictionary", FlipLibrarySubmenuIndexDictionary, callback_submenu_choices, app);
@@ -119,24 +113,26 @@ FlipLibraryApp *flip_library_app_alloc()
 
     // load settings
     if (load_settings(app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_size_ssid, app->uart_text_input_buffer_password, app->uart_text_input_buffer_size_password))
-    {
-        // Update variable items
-        if (app->variable_item_ssid)
-            variable_item_set_current_value_text(app->variable_item_ssid, app->uart_text_input_buffer_ssid);
-        // dont show password
+        {
+            // Update variable items
+            if (app->variable_item_ssid)
+                {
+                    variable_item_set_current_value_text(app->variable_item_ssid, app->uart_text_input_buffer_ssid);
+                }
+            // dont show password
 
-        // Copy items into their temp buffers with safety checks
-        if (app->uart_text_input_buffer_ssid && app->uart_text_input_temp_buffer_ssid)
-        {
-            strncpy(app->uart_text_input_temp_buffer_ssid, app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_size_ssid - 1);
-            app->uart_text_input_temp_buffer_ssid[app->uart_text_input_buffer_size_ssid - 1] = '\0';
+            // Copy items into their temp buffers with safety checks
+            if (app->uart_text_input_buffer_ssid && app->uart_text_input_temp_buffer_ssid)
+                {
+                    strncpy(app->uart_text_input_temp_buffer_ssid, app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_size_ssid - 1);
+                    app->uart_text_input_temp_buffer_ssid[app->uart_text_input_buffer_size_ssid - 1] = '\0';
+                }
+            if (app->uart_text_input_buffer_password && app->uart_text_input_temp_buffer_password)
+                {
+                    strncpy(app->uart_text_input_temp_buffer_password, app->uart_text_input_buffer_password, app->uart_text_input_buffer_size_password - 1);
+                    app->uart_text_input_temp_buffer_password[app->uart_text_input_buffer_size_password - 1] = '\0';
+                }
         }
-        if (app->uart_text_input_buffer_password && app->uart_text_input_temp_buffer_password)
-        {
-            strncpy(app->uart_text_input_temp_buffer_password, app->uart_text_input_buffer_password, app->uart_text_input_buffer_size_password - 1);
-            app->uart_text_input_temp_buffer_password[app->uart_text_input_buffer_size_password - 1] = '\0';
-        }
-    }
 
     // assign app instance
     app_instance = app;

--- a/application.fam
+++ b/application.fam
@@ -10,5 +10,5 @@ App(
     fap_description="Dictionary, random facts, and more.",
     fap_author="JBlanked",
     fap_weburl="https://github.com/jblanked/FlipLibrary",
-    fap_version = "1.2",
+    fap_version = "1.3",
 )

--- a/callback/flip_library_callback.c
+++ b/callback/flip_library_callback.c
@@ -1,760 +1,616 @@
 #include <callback/flip_library_callback.h>
-uint32_t random_facts_index = 0;
-bool sent_random_fact_request = false;
-bool random_fact_request_success = false;
-bool random_fact_request_success_all = false;
-char *random_fact = NULL;
 
-// Parse JSON to find the "text" key
-char *flip_library_parse_random_fact()
+// FURI_LOG_DEV will log only during app development. Be sure that Settings/System/Log Device is "LPUART"; so we dont use serial port.
+#ifdef DEVELOPMENT
+#define FURI_LOG_DEV(tag, format, ...) furi_log_print_format(FuriLogLevelInfo, tag, format, ##__VA_ARGS__)
+#define DEV_CRASH()                    furi_crash()
+#else
+#define FURI_LOG_DEV(tag, format, ...)
+#define DEV_CRASH()
+#endif
+
+static bool flip_library_random_fact_fetch(FactLoaderModel *model)
 {
+    UNUSED(model);
+    return flipper_http_get_request("https://uselessfacts.jsph.pl/api/v2/facts/random");
+}
+
+static char *flip_library_random_fact_parse(FactLoaderModel *model)
+{
+    UNUSED(model);
     return get_json_value("text", fhttp.last_response, 128);
 }
 
-char *flip_library_parse_cat_fact()
+static void flip_library_random_fact_switch_to_view(FlipLibraryApp *app)
 {
+    flip_library_generic_switch_to_view(app, "Random Fact", flip_library_random_fact_fetch, flip_library_random_fact_parse, 1, callback_to_random_facts, FlipLibraryViewLoader);
+}
+
+static bool flip_library_cat_fact_fetch(FactLoaderModel *model)
+{
+    UNUSED(model);
+    return flipper_http_get_request_with_headers("https://catfact.ninja/fact", "{\"Content-Type\":\"application/json\"}");
+}
+
+static char *flip_library_cat_fact_parse(FactLoaderModel *model)
+{
+    UNUSED(model);
     return get_json_value("fact", fhttp.last_response, 128);
 }
 
-char *flip_library_parse_dog_fact()
+static void flip_library_cat_fact_switch_to_view(FlipLibraryApp *app)
 {
+    flip_library_generic_switch_to_view(app, "Random Cat Fact", flip_library_cat_fact_fetch, flip_library_cat_fact_parse, 1, callback_to_random_facts, FlipLibraryViewLoader);
+}
+
+static bool flip_library_dog_fact_fetch(FactLoaderModel *model)
+{
+    UNUSED(model);
+    return flipper_http_get_request_with_headers("https://dog-api.kinduff.com/api/facts", "{\"Content-Type\":\"application/json\"}");
+}
+
+static char *flip_library_dog_fact_parse(FactLoaderModel *model)
+{
+    UNUSED(model);
     return get_json_array_value("facts", 0, fhttp.last_response, 256);
 }
 
-char *flip_library_parse_quote()
+static void flip_library_dog_fact_switch_to_view(FlipLibraryApp *app)
 {
+    flip_library_generic_switch_to_view(app, "Random Dog Fact", flip_library_dog_fact_fetch, flip_library_dog_fact_parse, 1, callback_to_random_facts, FlipLibraryViewLoader);
+}
+
+static bool flip_library_quote_fetch(FactLoaderModel *model)
+{
+    UNUSED(model);
+    return flipper_http_get_request("https://zenquotes.io/api/random");
+}
+
+static char *flip_library_quote_parse(FactLoaderModel *model)
+{
+    UNUSED(model);
     // remove [ and ] from the start and end of the string
     char *response = fhttp.last_response;
     if (response[0] == '[')
-    {
-        response++;
-    }
+        {
+            response++;
+        }
     if (response[strlen(response) - 1] == ']')
-    {
-        response[strlen(response) - 1] = '\0';
-    }
+        {
+            response[strlen(response) - 1] = '\0';
+        }
     // remove white space from both sides
     while (response[0] == ' ')
-    {
-        response++;
-    }
+        {
+            response++;
+        }
     while (response[strlen(response) - 1] == ' ')
-    {
-        response[strlen(response) - 1] = '\0';
-    }
+        {
+            response[strlen(response) - 1] = '\0';
+        }
     return get_json_value("q", response, 128);
 }
 
-char *flip_library_parse_dictionary()
+static void flip_library_quote_switch_to_view(FlipLibraryApp *app)
 {
-    return get_json_value("definition", fhttp.last_response, 16);
+    flip_library_generic_switch_to_view(app, "Random Quote", flip_library_quote_fetch, flip_library_quote_parse, 1, callback_to_random_facts, FlipLibraryViewLoader);
 }
 
-void flip_library_request_error(Canvas *canvas)
+static bool flip_library_dictionary_fetch(FactLoaderModel *model)
 {
-    if (fhttp.last_response == NULL)
-    {
-        if (fhttp.last_response != NULL)
+    UNUSED(model);
+    char payload[128];
+    snprintf(payload, sizeof(payload), "{\"word\":\"%s\"}", app_instance->uart_text_input_buffer_query);
+
+    return flipper_http_post_request_with_headers("https://www.flipsocial.net/api/define/", "{\"Content-Type\":\"application/json\"}", payload);
+}
+
+static char *flip_library_dictionary_parse(FactLoaderModel *model)
+{
+    UNUSED(model);
+    char *defn = get_json_value("definition", fhttp.last_response, 16);
+    if (defn == NULL)
+        {
+            defn = get_json_value("[ERROR]", fhttp.last_response, 16);
+        }
+    return defn;
+}
+
+static void flip_library_dictionary_switch_to_view(FlipLibraryApp *app)
+{
+    uart_text_input_set_header_text(app->uart_text_input_query, "Enter a word");
+    flip_library_generic_switch_to_view(app, "Defining", flip_library_dictionary_fetch, flip_library_dictionary_parse, 1, callback_to_submenu, FlipLibraryViewTextInputQuery);
+}
+
+static void flip_library_request_error_draw(Canvas *canvas)
+{
+    if (canvas == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_request_error_draw - canvas is NULL");
+            DEV_CRASH();
+            return;
+        }
+    if (fhttp.last_response != NULL)
         {
             if (strstr(fhttp.last_response, "[ERROR] Not connected to Wifi. Failed to reconnect.") != NULL)
-            {
-                canvas_clear(canvas);
-                canvas_draw_str(canvas, 0, 10, "[ERROR] Not connected to Wifi.");
-                canvas_draw_str(canvas, 0, 50, "Update your WiFi settings.");
-                canvas_draw_str(canvas, 0, 60, "Press BACK to return.");
-            }
+                {
+                    canvas_clear(canvas);
+                    canvas_draw_str(canvas, 0, 10, "[ERROR] Not connected to Wifi.");
+                    canvas_draw_str(canvas, 0, 22, "Failed to reconnect.");
+                    canvas_draw_str(canvas, 0, 50, "Update your WiFi settings.");
+                    canvas_draw_str(canvas, 0, 60, "Press BACK to return.");
+                }
             else if (strstr(fhttp.last_response, "[ERROR] Failed to connect to Wifi.") != NULL)
-            {
-                canvas_clear(canvas);
-                canvas_draw_str(canvas, 0, 10, "[ERROR] Not connected to Wifi.");
-                canvas_draw_str(canvas, 0, 50, "Update your WiFi settings.");
-                canvas_draw_str(canvas, 0, 60, "Press BACK to return.");
-            }
+                {
+                    canvas_clear(canvas);
+                    canvas_draw_str(canvas, 0, 10, "[ERROR] Not connected to Wifi.");
+                    canvas_draw_str(canvas, 0, 50, "Update your WiFi settings.");
+                    canvas_draw_str(canvas, 0, 60, "Press BACK to return.");
+                }
+            else if (strstr(fhttp.last_response, "[PONG]") != NULL)
+                {
+                    canvas_clear(canvas);
+                    canvas_draw_str(canvas, 0, 10, "[STATUS]Connecting to AP...");
+                }
             else
-            {
-                canvas_clear(canvas);
-                FURI_LOG_E(TAG, "Received an error: %s", fhttp.last_response);
-                canvas_draw_str(canvas, 0, 10, "[ERROR] Unusual error...");
-                canvas_draw_str(canvas, 0, 60, "Press BACK and retry.");
-            }
+                {
+                    canvas_clear(canvas);
+                    FURI_LOG_E(TAG, "Received an error: %s", fhttp.last_response);
+                    canvas_draw_str(canvas, 0, 10, "[ERROR] Unusual error...");
+                    canvas_draw_str(canvas, 0, 60, "Press BACK and retry.");
+                }
         }
-        else
+    else
         {
             canvas_clear(canvas);
-            canvas_draw_str(canvas, 0, 10, "[ERROR] Unknown error.");
-            canvas_draw_str(canvas, 0, 50, "Update your WiFi settings.");
+            canvas_draw_str(canvas, 0, 10, "Failed to receive data.");
             canvas_draw_str(canvas, 0, 60, "Press BACK to return.");
         }
-    }
-    else
-    {
-        canvas_clear(canvas);
-        canvas_draw_str(canvas, 0, 10, "Failed to receive data.");
-        canvas_draw_str(canvas, 0, 60, "Press BACK to return.");
-    }
 }
 
-void flip_library_draw_fact(char *message, Widget **widget)
+static void flip_library_widget_set_text(char *message, Widget **widget)
 {
-    if (app_instance == NULL)
-    {
-        FURI_LOG_E(TAG, "App instance is NULL");
-        return;
-    }
+    if (widget == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_set_widget_text - widget is NULL");
+            DEV_CRASH();
+            return;
+        }
+    if (message == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_set_widget_text - message is NULL");
+            DEV_CRASH();
+            return;
+        }
     widget_reset(*widget);
 
-    uint32_t fact_length = strlen(message); // Length of the message
-    uint32_t i = 0;                         // Index tracker
-    uint32_t formatted_index = 0;           // Tracker for where we are in the formatted message
-    char *formatted_message;                // Buffer to hold the final formatted message
-    if (!easy_flipper_set_buffer(&formatted_message, fact_length * 2 + 1))
-    {
-        return;
-    }
-
-    while (i < fact_length)
-    {
-        uint32_t max_line_length = 29;               // Maximum characters per line
-        uint32_t remaining_length = fact_length - i; // Remaining characters
-        uint32_t line_length = (remaining_length < max_line_length) ? remaining_length : max_line_length;
-
-        // Temporary buffer to hold the current line
-        char fact_line[30];
-        strncpy(fact_line, message + i, line_length);
-        fact_line[line_length] = '\0';
-
-        // Check if the line ends in the middle of a word and adjust accordingly
-        if (line_length == 29 && message[i + line_length] != '\0' && message[i + line_length] != ' ')
+    uint32_t message_length = strlen(message); // Length of the message
+    uint32_t i = 0; // Index tracker
+    uint32_t formatted_index = 0; // Tracker for where we are in the formatted message
+    char *formatted_message; // Buffer to hold the final formatted message
+    if (!easy_flipper_set_buffer(&formatted_message, message_length * 2 + 1))
         {
-            // Find the last space within the 30-character segment
-            char *last_space = strrchr(fact_line, ' ');
-            if (last_space != NULL)
-            {
-                // Adjust the line length to avoid cutting the word
-                line_length = last_space - fact_line;
-                fact_line[line_length] = '\0'; // Null-terminate at the space
-            }
+            return;
         }
 
-        // Manually copy the fixed line into the formatted_message buffer
-        for (uint32_t j = 0; j < line_length; j++)
+    while (i < message_length)
         {
-            formatted_message[formatted_index++] = fact_line[j];
+            // TODO: Use canvas_glyph_width to calculate the maximum characters for the line
+            uint32_t max_line_length = 29; // Maximum characters per line
+            uint32_t remaining_length = message_length - i; // Remaining characters
+            uint32_t line_length = (remaining_length < max_line_length) ? remaining_length : max_line_length;
+
+            // Temporary buffer to hold the current line
+            char line[30];
+            strncpy(line, message + i, line_length);
+            line[line_length] = '\0';
+
+            // Check if the line ends in the middle of a word and adjust accordingly
+            if (line_length == 29 && message[i + line_length] != '\0' && message[i + line_length] != ' ')
+                {
+                    // Find the last space within the 30-character segment
+                    char *last_space = strrchr(line, ' ');
+                    if (last_space != NULL)
+                        {
+                            // Adjust the line length to avoid cutting the word
+                            line_length = last_space - line;
+                            line[line_length] = '\0'; // Null-terminate at the space
+                        }
+                }
+
+            // Manually copy the fixed line into the formatted_message buffer
+            for (uint32_t j = 0; j < line_length; j++)
+                {
+                    formatted_message[formatted_index++] = line[j];
+                }
+
+            // Add a newline character for line spacing
+            formatted_message[formatted_index++] = '\n';
+
+            // Move i forward to the start of the next word
+            i += line_length;
+
+            // Skip spaces at the beginning of the next line
+            while (message[i] == ' ')
+                {
+                    i++;
+                }
         }
-
-        // Add a newline character for line spacing
-        formatted_message[formatted_index++] = '\n';
-
-        // Move i forward to the start of the next word
-        i += line_length;
-
-        // Skip spaces at the beginning of the next line
-        while (message[i] == ' ')
-        {
-            i++;
-        }
-    }
 
     // Add the formatted message to the widget
-    widget_add_text_scroll_element(
-        *widget,
-        0,
-        0,
-        128,
-        64,
-        formatted_message);
+    widget_add_text_scroll_element(*widget, 0, 0, 128, 64, formatted_message);
 }
 
-// Callback for drawing the main screen
-void view_draw_callback_random_facts(Canvas *canvas, void *model)
+void flip_library_loader_draw_callback(Canvas *canvas, void *model)
 {
-    if (!canvas || !app_instance)
-    {
-        return;
-    }
-    UNUSED(model);
+    if (!canvas || !model)
+        {
+            FURI_LOG_E(TAG, "flip_library_loader_draw_callback - canvas or model is NULL");
+            return;
+        }
+
+    SerialState http_state = fhttp.state;
+    FactLoaderModel *fact_loader_model = (FactLoaderModel*)model;
+    FactState fact_state = fact_loader_model->fact_state;
+    char *title = fact_loader_model->title;
 
     canvas_set_font(canvas, FontSecondary);
 
-    if (fhttp.state == INACTIVE)
-    {
-        canvas_draw_str(canvas, 0, 7, "Wifi Dev Board disconnected.");
-        canvas_draw_str(canvas, 0, 17, "Please connect to the board.");
-        canvas_draw_str(canvas, 0, 32, "If your board is connected,");
-        canvas_draw_str(canvas, 0, 42, "make sure you have flashed");
-        canvas_draw_str(canvas, 0, 52, "your WiFi Devboard with the");
-        canvas_draw_str(canvas, 0, 62, "latest FlipperHTTP flash.");
-        return;
-    }
-    // Cats
-    if (random_facts_index == FlipLibrarySubmenuIndexRandomFactsCats)
-    {
-        canvas_draw_str(canvas, 0, 7, "Random Cat Fact");
-        canvas_draw_str(canvas, 0, 15, "Loading...");
-
-        if (!sent_random_fact_request)
+    if (http_state == INACTIVE)
         {
-            sent_random_fact_request = true;
-            random_fact_request_success = flipper_http_get_request_with_headers("https://catfact.ninja/fact", "{\"Content-Type\":\"application/json\"}");
-            if (!random_fact_request_success)
-            {
-                FURI_LOG_E(TAG, "Failed to send request");
-                flip_library_request_error(canvas);
-                return;
-            }
-            fhttp.state = RECEIVING;
+            canvas_draw_str(canvas, 0, 7, "Wifi Dev Board disconnected.");
+            canvas_draw_str(canvas, 0, 17, "Please connect to the board.");
+            canvas_draw_str(canvas, 0, 32, "If your board is connected,");
+            canvas_draw_str(canvas, 0, 42, "make sure you have flashed");
+            canvas_draw_str(canvas, 0, 52, "your WiFi Devboard with the");
+            canvas_draw_str(canvas, 0, 62, "latest FlipperHTTP flash.");
+            return;
         }
-        else
+
+    if (fact_state == FactStateError || fact_state == FactStateParseError)
         {
-            if (fhttp.state == RECEIVING)
-            {
-                canvas_draw_str(canvas, 0, 22, "Receiving...");
-                return;
-            }
-            // check status
-            else if (fhttp.state == ISSUE || !random_fact_request_success)
-            {
-                flip_library_request_error(canvas);
-            }
-            else if (fhttp.state == IDLE && fhttp.last_response != NULL && !random_fact_request_success_all)
-            {
-                canvas_draw_str(canvas, 0, 22, "Processing...");
-                // success
-                // check status
-                // unnecessary check
-                if (fhttp.state == ISSUE || fhttp.last_response == NULL)
-                {
-                    flip_library_request_error(canvas);
-                    FURI_LOG_E(TAG, "HTTP request failed or received data is NULL");
-                    return;
-                }
-                else if (!random_fact_request_success_all)
-                {
-                    random_fact = flip_library_parse_cat_fact();
-
-                    if (random_fact == NULL)
-                    {
-                        flip_library_request_error(canvas);
-                        fhttp.state = ISSUE;
-                        return;
-                    }
-
-                    // Mark success
-                    random_fact_request_success_all = true;
-
-                    // draw random facts
-                    flip_library_draw_fact(random_fact, &app_instance->widget_random_fact);
-
-                    // go to random facts widget
-                    view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewRandomFactWidget);
-                }
-            }
-            // likely redundant but just in case
-            else if (fhttp.state == IDLE && random_fact_request_success_all && random_fact != NULL)
-            {
-                flip_library_draw_fact(random_fact, &app_instance->widget_random_fact);
-
-                // go to random facts widget
-                view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewRandomFactWidget);
-            }
-            else // handle weird scenarios
-            {
-                // if received data isnt NULL
-                if (fhttp.last_response != NULL)
-                {
-                    // parse json to find the text key
-                    random_fact = flip_library_parse_cat_fact();
-
-                    if (random_fact == NULL)
-                    {
-                        flip_library_request_error(canvas);
-                        fhttp.state = ISSUE;
-                        return;
-                    }
-                }
-            }
+            flip_library_request_error_draw(canvas);
+            return;
         }
-    }
-    // Dogs
-    else if (random_facts_index == FlipLibrarySubmenuIndexRandomFactsDogs)
-    {
-        canvas_draw_str(canvas, 0, 7, "Random Dog Fact");
-        canvas_draw_str(canvas, 0, 15, "Loading...");
 
-        if (!sent_random_fact_request)
+    canvas_draw_str(canvas, 0, 7, title);
+    canvas_draw_str(canvas, 0, 15, "Loading...");
+
+    if (fact_state == FactStateInitial)
         {
-            sent_random_fact_request = true;
-            random_fact_request_success = flipper_http_get_request_with_headers("https://dog-api.kinduff.com/api/facts", "{\"Content-Type\":\"application/json\"}");
-            if (!random_fact_request_success)
-            {
-                FURI_LOG_E(TAG, "Failed to send request");
-                flip_library_request_error(canvas);
-                fhttp.state = ISSUE;
-                return;
-            }
-            fhttp.state = RECEIVING;
+            return;
         }
-        else
+
+    if (http_state == SENDING)
         {
-            if (fhttp.state == RECEIVING)
-            {
-                canvas_draw_str(canvas, 0, 22, "Receiving...");
-                return;
-            }
-            // check status
-            else if (fhttp.state == ISSUE || !random_fact_request_success)
-            {
-                flip_library_request_error(canvas);
-            }
-            else if (fhttp.state == IDLE && fhttp.last_response != NULL && !random_fact_request_success_all)
-            {
-                canvas_draw_str(canvas, 0, 22, "Processing...");
-                // success
-                // check status
-                // unnecessary check
-                if (fhttp.state == ISSUE || fhttp.last_response == NULL)
-                {
-                    flip_library_request_error(canvas);
-                    FURI_LOG_E(TAG, "HTTP request failed or received data is NULL");
-                    return;
-                }
-                else if (!random_fact_request_success_all)
-                {
-                    random_fact = flip_library_parse_dog_fact();
-
-                    if (random_fact == NULL)
-                    {
-                        flip_library_request_error(canvas);
-                        fhttp.state = ISSUE;
-                        return;
-                    }
-
-                    // Mark success
-                    random_fact_request_success_all = true;
-
-                    // draw random facts
-                    flip_library_draw_fact(random_fact, &app_instance->widget_random_fact);
-
-                    // go to random facts widget
-                    view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewRandomFactWidget);
-                }
-            }
-            // likely redundant but just in case
-            else if (fhttp.state == IDLE && random_fact_request_success_all && random_fact != NULL)
-            {
-                flip_library_draw_fact(random_fact, &app_instance->widget_random_fact);
-
-                // go to random facts widget
-                view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewRandomFactWidget);
-            }
-            else // handle weird scenarios
-            {
-                // if received data isnt NULL
-                if (fhttp.last_response != NULL)
-                {
-                    // parse json to find the text key
-                    random_fact = flip_library_parse_cat_fact();
-
-                    if (random_fact == NULL)
-                    {
-                        flip_library_request_error(canvas);
-                        fhttp.state = ISSUE;
-                        return;
-                    }
-                }
-            }
+            canvas_draw_str(canvas, 0, 22, "Sending...");
+            return;
         }
-    }
-    // Quotes
-    else if (random_facts_index == FlipLibrarySubmenuIndexRandomFactsQuotes)
-    {
-        canvas_draw_str(canvas, 0, 7, "Random Quote");
-        canvas_draw_str(canvas, 0, 15, "Loading...");
 
-        if (!sent_random_fact_request)
+    if (http_state == RECEIVING || fact_state == FactStateRequested)
         {
-            sent_random_fact_request = true;
-            random_fact_request_success = flipper_http_get_request("https://zenquotes.io/api/random");
-            if (!random_fact_request_success)
-            {
-                FURI_LOG_E(TAG, "Failed to send request");
-                flip_library_request_error(canvas);
-                return;
-            }
-            fhttp.state = RECEIVING;
+            canvas_draw_str(canvas, 0, 22, "Receiving...");
+            return;
         }
-        else
+
+    if (http_state == IDLE && fact_state == FactStateReceived)
         {
-            if (fhttp.state == RECEIVING)
-            {
-                canvas_draw_str(canvas, 0, 22, "Receiving...");
-                return;
-            }
-            // check status
-            else if (fhttp.state == ISSUE || !random_fact_request_success)
-            {
-                flip_library_request_error(canvas);
-            }
-            else if (fhttp.state == IDLE && fhttp.last_response != NULL && !random_fact_request_success_all)
-            {
-                canvas_draw_str(canvas, 0, 22, "Processing...");
-                // success
-                // check status
-                // unnecessary check
-                if (fhttp.state == ISSUE || fhttp.last_response == NULL)
-                {
-                    flip_library_request_error(canvas);
-                    FURI_LOG_E(TAG, "HTTP request failed or received data is NULL");
-                    return;
-                }
-                else if (!random_fact_request_success_all)
-                {
-                    random_fact = flip_library_parse_quote();
-
-                    if (random_fact == NULL)
-                    {
-                        flip_library_request_error(canvas);
-                        fhttp.state = ISSUE;
-                        return;
-                    }
-
-                    // Mark success
-                    random_fact_request_success_all = true;
-
-                    // draw random facts
-                    flip_library_draw_fact(random_fact, &app_instance->widget_random_fact);
-
-                    // go to random facts widget
-                    view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewRandomFactWidget);
-                }
-            }
-            // likely redundant but just in case
-            else if (fhttp.state == IDLE && random_fact_request_success_all && random_fact != NULL)
-            {
-                flip_library_draw_fact(random_fact, &app_instance->widget_random_fact);
-
-                // go to random facts widget
-                view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewRandomFactWidget);
-            }
-            else // handle weird scenarios
-            {
-                // if received data isnt NULL
-                if (fhttp.last_response != NULL)
-                {
-                    // parse json to find the text key
-                    random_fact = flip_library_parse_quote();
-
-                    if (random_fact == NULL)
-                    {
-                        flip_library_request_error(canvas);
-                        fhttp.state = ISSUE;
-                        return;
-                    }
-                }
-            }
+            canvas_draw_str(canvas, 0, 22, "Processing...");
+            return;
         }
-    }
-    // All Random Facts
-    else if (random_facts_index == FlipLibrarySubmenuIndexRandomFactsAll)
-    {
-        canvas_draw_str(canvas, 0, 10, "Random Fact");
-        canvas_set_font(canvas, FontSecondary);
-        canvas_draw_str(canvas, 0, 20, "Loading...");
 
-        if (!sent_random_fact_request)
+    if (http_state == IDLE && fact_state == FactStateParsed)
         {
-            sent_random_fact_request = true;
-
-            random_fact_request_success = flipper_http_get_request("https://uselessfacts.jsph.pl/api/v2/facts/random");
-            if (!random_fact_request_success)
-            {
-                FURI_LOG_E(TAG, "Failed to send request");
-                fhttp.state = ISSUE;
-                return;
-            }
-            fhttp.state = RECEIVING;
+            canvas_draw_str(canvas, 0, 22, "Processed...");
+            return;
         }
-        else
-        {
-            // check status
-            if (fhttp.state == RECEIVING)
-            {
-                canvas_draw_str(canvas, 0, 30, "Receiving...");
-                return;
-            }
-            // check status
-            else if (fhttp.state == ISSUE || !random_fact_request_success)
-            {
-                flip_library_request_error(canvas);
-                return;
-            }
-            else if (fhttp.state == IDLE && fhttp.last_response != NULL && !random_fact_request_success_all)
-            {
-                canvas_draw_str(canvas, 0, 30, "Processing...");
-                // success
-                // check status
-                if (fhttp.state == ISSUE || fhttp.last_response == NULL)
-                {
-                    flip_library_request_error(canvas);
-                    FURI_LOG_E(TAG, "HTTP request failed or received data is NULL");
-                    return;
-                }
-
-                // parse json to find the text key
-                random_fact = flip_library_parse_random_fact();
-
-                if (random_fact == NULL)
-                {
-                    flip_library_request_error(canvas);
-                    fhttp.state = ISSUE;
-                    return;
-                }
-
-                // Mark success
-                random_fact_request_success_all = true;
-
-                // draw random facts
-                flip_library_draw_fact(random_fact, &app_instance->widget_random_fact);
-
-                // go to random facts widget
-                view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewRandomFactWidget);
-            }
-            // likely redundant but just in case
-            else if (fhttp.state == IDLE && random_fact_request_success_all && random_fact != NULL)
-            {
-                // draw random facts
-                flip_library_draw_fact(random_fact, &app_instance->widget_random_fact);
-
-                // go to random facts widget
-                view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewRandomFactWidget);
-            }
-            else // handle weird scenarios
-            {
-                // if received data isnt NULL
-                if (fhttp.last_response != NULL)
-                {
-                    // parse json to find the text key
-                    random_fact = flip_library_parse_random_fact();
-
-                    if (random_fact == NULL)
-                    {
-                        flip_library_request_error(canvas);
-                        fhttp.state = ISSUE;
-                        return;
-                    }
-                }
-            }
-        }
-    }
-    else
-    {
-        canvas_draw_str(canvas, 0, 7, "Random Fact");
-    }
 }
 
-void view_draw_callback_dictionary_run(Canvas *canvas, void *model)
+static void flip_library_loader_process_callback(void *context)
 {
-    if (!canvas || !app_instance || app_instance->uart_text_input_buffer_dictionary == NULL)
-    {
-        return;
-    }
-
-    UNUSED(model);
-
-    canvas_set_font(canvas, FontSecondary);
-
-    if (fhttp.state == INACTIVE)
-    {
-        canvas_draw_str(canvas, 0, 7, "Wifi Dev Board disconnected.");
-        canvas_draw_str(canvas, 0, 17, "Please connect to the board.");
-        canvas_draw_str(canvas, 0, 32, "If your board is connected,");
-        canvas_draw_str(canvas, 0, 42, "make sure you have flashed");
-        canvas_draw_str(canvas, 0, 52, "your WiFi Devboard with the");
-        canvas_draw_str(canvas, 0, 62, "latest FlipperHTTP flash.");
-        return;
-    }
-
-    canvas_draw_str(canvas, 0, 10, "Defining, please wait...");
-
-    if (!sent_random_fact_request)
-    {
-        sent_random_fact_request = true;
-
-        char payload[128];
-        snprintf(payload, sizeof(payload), "{\"word\":\"%s\"}", app_instance->uart_text_input_buffer_dictionary);
-
-        random_fact_request_success = flipper_http_post_request_with_headers("https://www.flipsocial.net/api/define/", "{\"Content-Type\":\"application/json\"}", payload);
-        if (!random_fact_request_success)
+    if (context == NULL)
         {
-            FURI_LOG_E(TAG, "Failed to send request");
-            flip_library_request_error(canvas);
-            fhttp.state = ISSUE;
+            FURI_LOG_E(TAG, "flip_library_loader_process_callback - context is NULL");
+            DEV_CRASH();
             return;
         }
-        fhttp.state = RECEIVING;
-    }
-    else
-    {
-        // check status
-        if (fhttp.state == RECEIVING)
+
+    FlipLibraryApp *app = (FlipLibraryApp*)context;
+    View *view = app->view_loader;
+
+    FactState current_fact_state;
+    with_view_model(view, FactLoaderModel *model, { current_fact_state = model->fact_state; }, false);
+
+    if (current_fact_state == FactStateInitial)
         {
-            canvas_draw_str(canvas, 0, 20, "Receiving...");
-            return;
-        }
-        // check status
-        else if (fhttp.state == ISSUE || !random_fact_request_success)
-        {
-            flip_library_request_error(canvas);
-            return;
-        }
-        else if (fhttp.state == IDLE && fhttp.last_response != NULL && !random_fact_request_success_all)
-        {
-            canvas_draw_str(canvas, 0, 20, "Processing...");
-            // success
-            // check status
-            if (fhttp.state == ISSUE || fhttp.last_response == NULL)
-            {
-                flip_library_request_error(canvas);
-                FURI_LOG_E(TAG, "HTTP request failed or received data is NULL");
-                return;
-            }
-
-            // parse json to find the text key
-            char *definition = flip_library_parse_dictionary();
-
-            if (definition == NULL)
-            {
-                flip_library_request_error(canvas);
-                fhttp.state = ISSUE;
-                return;
-            }
-
-            // Mark success
-            random_fact_request_success_all = true;
-
-            // draw random facts
-            flip_library_draw_fact(definition, &app_instance->widget_dictionary);
-
-            // go to random facts widget
-            view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewDictionaryWidget);
-        }
-        // likely redundant but just in case
-        else if (fhttp.state == IDLE && random_fact_request_success_all && random_fact != NULL)
-        {
-            // draw random facts
-            flip_library_draw_fact(random_fact, &app_instance->widget_dictionary);
-
-            // go to random facts widget
-            view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewDictionaryWidget);
-        }
-        else // handle weird scenarios
-        {
-            // if received data isnt NULL
-            if (fhttp.last_response != NULL)
-            {
-                // parse json to find the text key
-                char *definition = flip_library_parse_dictionary();
-
-                if (definition == NULL)
+            with_view_model(
+                view,
+                FactLoaderModel *model,
                 {
-                    flip_library_request_error(canvas);
-                    fhttp.state = ISSUE;
-                    return;
-                }
+                    model->fact_state = FactStateRequested;
+                    FactLoaderFetch fetch = model->fetcher;
+                    if (fetch == NULL)
+                        {
+                            FURI_LOG_E(TAG, "Model doesn't have Fetch function assigned.");
+                            model->fact_state = FactStateError;
+                            return;
+                        }
 
-                // draw random facts
-                flip_library_draw_fact(definition, &app_instance->widget_dictionary);
-
-                // go to random facts widget
-                view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewDictionaryWidget);
-
-                free(definition);
-
-                return;
-            }
+                    // Clear any previous responses
+                    strncpy(fhttp.last_response, "", 1);
+                    bool request_status = fetch(model);
+                    if (!request_status)
+                        {
+                            model->fact_state = FactStateError;
+                        }
+                },
+                true);
         }
-    }
+    else if (current_fact_state == FactStateRequested || current_fact_state == FactStateError)
+        {
+            if (fhttp.state == IDLE && fhttp.last_response != NULL)
+                {
+                    if (strstr(fhttp.last_response, "[PONG]") != NULL)
+                        {
+                            FURI_LOG_DEV(TAG, "PONG received.");
+                        }
+                    else if (strncmp(fhttp.last_response, "[SUCCESS]", 9) == 0)
+                        {
+                            FURI_LOG_DEV(TAG, "SUCCESS received. %s", fhttp.last_response ? fhttp.last_response : "NULL");
+                        }
+                    else if (strncmp(fhttp.last_response, "[ERROR]", 9) == 0)
+                        {
+                            FURI_LOG_DEV(TAG, "ERROR received. %s", fhttp.last_response ? fhttp.last_response : "NULL");
+                        }
+                    else if (strlen(fhttp.last_response) == 0)
+                        {
+                            // Still waiting on response
+                        }
+                    else
+                        {
+                            with_view_model(view, FactLoaderModel *model, { model->fact_state = FactStateReceived; }, true);
+                        }
+                }
+            else if (fhttp.state == SENDING || fhttp.state == RECEIVING)
+                {
+                    // continue waiting
+                }
+            else if (fhttp.state == INACTIVE)
+                {
+                    // inactive. try again
+                }
+            else if (fhttp.state == ISSUE)
+                {
+                    with_view_model(view, FactLoaderModel *model, { model->fact_state = FactStateError; }, true);
+                }
+            else
+                {
+                    FURI_LOG_DEV(TAG, "Unexpected state: %d lastresp: %s", fhttp.state, fhttp.last_response ? fhttp.last_response : "NULL");
+                    DEV_CRASH();
+                }
+        }
+    else if (current_fact_state == FactStateReceived)
+        {
+            with_view_model(
+                view,
+                FactLoaderModel *model,
+                {
+                    char *fact_text;
+                    if (model->parser == NULL)
+                        {
+                            fact_text = NULL;
+                            FURI_LOG_DEV(TAG, "Parser is NULL");
+                            DEV_CRASH();
+                        }
+                    else
+                        {
+                            fact_text = model->parser(model);
+                        }
+                    FURI_LOG_DEV(TAG, "Parsed fact: %s\r\ntext: %s", fhttp.last_response ? fhttp.last_response : "NULL", fact_text ? fact_text : "NULL");
+                    model->fact_text = fact_text;
+                    if (fact_text == NULL)
+                        {
+                            model->fact_state = FactStateParseError;
+                        }
+                    else
+                        {
+                            model->fact_state = FactStateParsed;
+                        }
+                },
+                true);
+        }
+    else if (current_fact_state == FactStateParsed)
+        {
+            with_view_model(
+                view,
+                FactLoaderModel *model,
+                {
+                    if (++model->request_index < model->request_count)
+                        {
+                            model->fact_state = FactStateInitial;
+                        }
+                    else
+                        {
+                            flip_library_widget_set_text(model->fact_text != NULL ? model->fact_text : "Empty result", &app_instance->widget_result);
+                            if (model->fact_text != NULL)
+                                {
+                                    free(model->fact_text);
+                                    model->fact_text = NULL;
+                                }
+                            view_set_previous_callback(widget_get_view(app_instance->widget_result), model->back_callback);
+                            view_dispatcher_switch_to_view(app_instance->view_dispatcher, FlipLibraryViewWidgetResult);
+                        }
+                },
+                true);
+        }
 }
 
-// Input callback for the view (async input handling)
-bool view_input_callback_random_facts(InputEvent *event, void *context)
+static void flip_library_loader_timer_callback(void *context)
 {
-    if (!event || !context)
-    {
-        return false;
-    }
-    FlipLibraryApp *app = (FlipLibraryApp *)context;
-    if (event->type == InputTypePress && event->key == InputKeyBack)
-    {
-        // Exit the app when the back button is pressed
-        view_dispatcher_stop(app->view_dispatcher);
-        return true;
-    }
-    return false;
+    if (context == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_loader_timer_callback - context is NULL");
+            DEV_CRASH();
+            return;
+        }
+    FlipLibraryApp *app = (FlipLibraryApp*)context;
+    view_dispatcher_send_custom_event(app->view_dispatcher, FlipLibraryCustomEventProcess);
+}
+
+static void flip_library_loader_on_enter(void *context)
+{
+    if (context == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_loader_on_enter - context is NULL");
+            DEV_CRASH();
+            return;
+        }
+    FlipLibraryApp *app = (FlipLibraryApp*)context;
+    View *view = app->view_loader;
+    with_view_model(
+        view,
+        FactLoaderModel *model,
+        {
+            view_set_previous_callback(view, model->back_callback);
+            if (model->timer == NULL)
+                {
+                    model->timer = furi_timer_alloc(flip_library_loader_timer_callback, FuriTimerTypePeriodic, app);
+                }
+            furi_timer_start(model->timer, 250);
+        },
+        true);
+}
+
+static void flip_library_loader_on_exit(void *context)
+{
+    if (context == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_loader_on_exit - context is NULL");
+            DEV_CRASH();
+            return;
+        }
+    FlipLibraryApp *app = (FlipLibraryApp*)context;
+    View *view = app->view_loader;
+    with_view_model(
+        view,
+        FactLoaderModel *model,
+        {
+            if (model->timer)
+                {
+                    furi_timer_stop(model->timer);
+                }
+        },
+        false);
+}
+
+void flip_library_loader_init(View *view)
+{
+    if (view == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_loader_init - view is NULL");
+            DEV_CRASH();
+            return;
+        }
+    view_allocate_model(view, ViewModelTypeLocking, sizeof(FactLoaderModel));
+    view_set_enter_callback(view, flip_library_loader_on_enter);
+    view_set_exit_callback(view, flip_library_loader_on_exit);
+}
+
+void flip_library_loader_free_model(View *view)
+{
+    if (view == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_loader_free_model - view is NULL");
+            DEV_CRASH();
+            return;
+        }
+    with_view_model(
+        view,
+        FactLoaderModel *model,
+        {
+            if (model->timer)
+                {
+                    furi_timer_free(model->timer);
+                    model->timer = NULL;
+                }
+            if (model->parser_context)
+                {
+                    free(model->parser_context);
+                    model->parser_context = NULL;
+                }
+        },
+        false);
+}
+
+bool flip_library_custom_event_callback(void *context, uint32_t index)
+{
+    if (context == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_custom_event_callback - context is NULL");
+            DEV_CRASH();
+            return false;
+        }
+
+    switch (index)
+        {
+        case FlipLibraryCustomEventProcess:
+            flip_library_loader_process_callback(context);
+            return true;
+        default:
+            FURI_LOG_DEV(TAG, "flip_library_custom_event_callback. Unknown index: %ld", index);
+            return false;
+        }
 }
 
 void callback_submenu_choices(void *context, uint32_t index)
 {
-    FlipLibraryApp *app = (FlipLibraryApp *)context;
-    if (!app)
-    {
-        FURI_LOG_E(TAG, "FlipLibraryApp is NULL");
-        return;
-    }
+    if (context == NULL)
+        {
+            FURI_LOG_E(TAG, "callback_submenu_choices - context is NULL");
+            DEV_CRASH();
+            return;
+        }
+    FlipLibraryApp *app = (FlipLibraryApp*)context;
     switch (index)
-    {
-    case FlipLibrarySubmenuIndexRandomFacts:
-        random_facts_index = 0;
-        sent_random_fact_request = false;
-        random_fact = NULL;
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewRandomFacts);
-        break;
-    case FlipLibrarySubmenuIndexAbout:
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewAbout);
-        break;
-    case FlipLibrarySubmenuIndexSettings:
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewSettings);
-        break;
-    case FlipLibrarySubmenuIndexDictionary:
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewDictionaryTextInput);
-        break;
-    case FlipLibrarySubmenuIndexRandomFactsCats:
-        random_facts_index = FlipLibrarySubmenuIndexRandomFactsCats;
-        sent_random_fact_request = false;
-        random_fact = NULL;
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewRandomFactsRun);
-        break;
-    case FlipLibrarySubmenuIndexRandomFactsDogs:
-        random_facts_index = FlipLibrarySubmenuIndexRandomFactsDogs;
-        sent_random_fact_request = false;
-        random_fact = NULL;
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewRandomFactsRun);
-        break;
-    case FlipLibrarySubmenuIndexRandomFactsQuotes:
-        random_facts_index = FlipLibrarySubmenuIndexRandomFactsQuotes;
-        sent_random_fact_request = false;
-        random_fact = NULL;
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewRandomFactsRun);
-        break;
-    case FlipLibrarySubmenuIndexRandomFactsAll:
-        random_facts_index = FlipLibrarySubmenuIndexRandomFactsAll;
-        sent_random_fact_request = false;
-        random_fact = NULL;
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewRandomFactsRun);
-        break;
-    default:
-        break;
-    }
+        {
+        case FlipLibrarySubmenuIndexRandomFacts:
+            view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewRandomFacts);
+            break;
+        case FlipLibrarySubmenuIndexAbout:
+            view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewAbout);
+            break;
+        case FlipLibrarySubmenuIndexSettings:
+            view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewSettings);
+            break;
+        case FlipLibrarySubmenuIndexDictionary:
+            flip_library_dictionary_switch_to_view(app);
+            break;
+        case FlipLibrarySubmenuIndexRandomFactsCats:
+            flip_library_cat_fact_switch_to_view(app);
+            break;
+        case FlipLibrarySubmenuIndexRandomFactsDogs:
+            flip_library_dog_fact_switch_to_view(app);
+            break;
+        case FlipLibrarySubmenuIndexRandomFactsQuotes:
+            flip_library_quote_switch_to_view(app);
+            break;
+        case FlipLibrarySubmenuIndexRandomFactsAll:
+            flip_library_random_fact_switch_to_view(app);
+            break;
+        default:
+            break;
+        }
 }
 
 void text_updated_ssid(void *context)
 {
-    FlipLibraryApp *app = (FlipLibraryApp *)context;
+    FlipLibraryApp *app = (FlipLibraryApp*)context;
     if (!app)
-    {
-        FURI_LOG_E(TAG, "FlipLibraryApp is NULL");
-        return;
-    }
+        {
+            FURI_LOG_E(TAG, "text_updated_ssid - FlipLibraryApp is NULL");
+            DEV_CRASH();
+            return;
+        }
 
     // store the entered text
     strncpy(app->uart_text_input_buffer_ssid, app->uart_text_input_temp_buffer_ssid, app->uart_text_input_buffer_size_ssid);
@@ -764,21 +620,21 @@ void text_updated_ssid(void *context)
 
     // update the variable item text
     if (app->variable_item_ssid)
-    {
-        variable_item_set_current_value_text(app->variable_item_ssid, app->uart_text_input_buffer_ssid);
-    }
+        {
+            variable_item_set_current_value_text(app->variable_item_ssid, app->uart_text_input_buffer_ssid);
+        }
 
     // save settings
     save_settings(app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_password);
 
     // save wifi settings to devboard
     if (strlen(app->uart_text_input_buffer_ssid) > 0 && strlen(app->uart_text_input_buffer_password) > 0)
-    {
-        if (!flipper_http_save_wifi(app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_password))
         {
-            FURI_LOG_E(TAG, "Failed to save wifi settings");
+            if (!flipper_http_save_wifi(app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_password))
+                {
+                    FURI_LOG_E(TAG, "Failed to save wifi settings.");
+                }
         }
-    }
 
     // switch to the settings view
     view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewSettings);
@@ -786,12 +642,13 @@ void text_updated_ssid(void *context)
 
 void text_updated_password(void *context)
 {
-    FlipLibraryApp *app = (FlipLibraryApp *)context;
+    FlipLibraryApp *app = (FlipLibraryApp*)context;
     if (!app)
-    {
-        FURI_LOG_E(TAG, "FlipLibraryApp is NULL");
-        return;
-    }
+        {
+            FURI_LOG_E(TAG, "text_updated_password - FlipLibraryApp is NULL");
+            DEV_CRASH();
+            return;
+        }
 
     // store the entered text
     strncpy(app->uart_text_input_buffer_password, app->uart_text_input_temp_buffer_password, app->uart_text_input_buffer_size_password);
@@ -801,103 +658,85 @@ void text_updated_password(void *context)
 
     // update the variable item text
     if (app->variable_item_password)
-    {
-        variable_item_set_current_value_text(app->variable_item_password, app->uart_text_input_buffer_password);
-    }
+        {
+            variable_item_set_current_value_text(app->variable_item_password, app->uart_text_input_buffer_password);
+        }
 
     // save settings
     save_settings(app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_password);
 
     // save wifi settings to devboard
     if (strlen(app->uart_text_input_buffer_ssid) > 0 && strlen(app->uart_text_input_buffer_password) > 0)
-    {
-        if (!flipper_http_save_wifi(app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_password))
         {
-            FURI_LOG_E(TAG, "Failed to save wifi settings");
+            if (!flipper_http_save_wifi(app->uart_text_input_buffer_ssid, app->uart_text_input_buffer_password))
+                {
+                    FURI_LOG_E(TAG, "Failed to save wifi settings");
+                }
         }
-    }
 
     // switch to the settings view
     view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewSettings);
 }
 
-void text_updated_dictionary(void *context)
+void text_updated_query(void *context)
 {
-    FlipLibraryApp *app = (FlipLibraryApp *)context;
+    FlipLibraryApp *app = (FlipLibraryApp*)context;
     if (!app)
-    {
-        FURI_LOG_E(TAG, "FlipLibraryApp is NULL");
-        return;
-    }
+        {
+            FURI_LOG_E(TAG, "text_updated_query - FlipLibraryApp is NULL");
+            DEV_CRASH();
+            return;
+        }
 
     // store the entered text
-    strncpy(app->uart_text_input_buffer_dictionary, app->uart_text_input_temp_buffer_dictionary, app->uart_text_input_buffer_size_dictionary);
+    strncpy(app->uart_text_input_buffer_query, app->uart_text_input_temp_buffer_query, app->uart_text_input_buffer_size_query);
 
     // Ensure null-termination
-    app->uart_text_input_buffer_dictionary[app->uart_text_input_buffer_size_dictionary - 1] = '\0';
+    app->uart_text_input_buffer_query[app->uart_text_input_buffer_size_query - 1] = '\0';
 
-    // switch to the dictionary view
-    view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewDictionaryRun);
+    // switch to the loader view
+    view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewLoader);
 }
 
 uint32_t callback_to_submenu(void *context)
 {
-    if (!context)
-    {
-        FURI_LOG_E(TAG, "Context is NULL");
-        return VIEW_NONE;
-    }
     UNUSED(context);
-    random_facts_index = 0;
-    sent_random_fact_request = false;
-    random_fact_request_success = false;
-    random_fact_request_success_all = false;
-    random_fact = NULL;
     return FlipLibraryViewSubmenuMain;
 }
 
 uint32_t callback_to_wifi_settings(void *context)
 {
-    if (!context)
-    {
-        FURI_LOG_E(TAG, "Context is NULL");
-        return VIEW_NONE;
-    }
     UNUSED(context);
     return FlipLibraryViewSettings;
 }
 
 uint32_t callback_to_random_facts(void *context)
 {
-    if (!context)
-    {
-        FURI_LOG_E(TAG, "Context is NULL");
-        return VIEW_NONE;
-    }
     UNUSED(context);
     return FlipLibraryViewRandomFacts;
 }
 
 void settings_item_selected(void *context, uint32_t index)
 {
-    FlipLibraryApp *app = (FlipLibraryApp *)context;
+    FlipLibraryApp *app = (FlipLibraryApp*)context;
     if (!app)
-    {
-        FURI_LOG_E(TAG, "FlipLibraryApp is NULL");
-        return;
-    }
+        {
+            FURI_LOG_E(TAG, "settings_item_selected - FlipLibraryApp is NULL");
+            DEV_CRASH();
+            return;
+        }
     switch (index)
-    {
-    case 0: // Input SSID
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewTextInputSSID);
-        break;
-    case 1: // Input Password
-        view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewTextInputPassword);
-        break;
-    default:
-        FURI_LOG_E(TAG, "Unknown configuration item index");
-        break;
-    }
+        {
+        case 0: // Input SSID
+            view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewTextInputSSID);
+            break;
+        case 1: // Input Password
+            view_dispatcher_switch_to_view(app->view_dispatcher, FlipLibraryViewTextInputPassword);
+            break;
+        default:
+            FURI_LOG_E(TAG, "Unknown configuration item index");
+            break;
+        }
 }
 
 /**
@@ -909,10 +748,45 @@ uint32_t callback_exit_app(void *context)
 {
     // Exit the application
     if (!context)
-    {
-        FURI_LOG_E(TAG, "Context is NULL");
-        return VIEW_NONE;
-    }
+        {
+            FURI_LOG_E(TAG, "callback_exit_app - Context is NULL");
+            return VIEW_NONE;
+        }
     UNUSED(context);
     return VIEW_NONE; // Return VIEW_NONE to exit the app
+}
+
+void flip_library_generic_switch_to_view(FlipLibraryApp *app, char *title, FactLoaderFetch fetcher, FactLoaderParser parser, size_t request_count, ViewNavigationCallback back, uint32_t view_id)
+{
+    if (app == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_generic_switch_to_view - app is NULL");
+            DEV_CRASH();
+            return;
+        }
+
+    View *view = app->view_loader;
+    if (view == NULL)
+        {
+            FURI_LOG_E(TAG, "flip_library_generic_switch_to_view - view is NULL");
+            DEV_CRASH();
+            return;
+        }
+
+    with_view_model(
+        view,
+        FactLoaderModel *model,
+        {
+            model->title = title;
+            model->fetcher = fetcher;
+            model->parser = parser;
+            model->request_index = 0;
+            model->request_count = request_count;
+            model->back_callback = back;
+            model->fact_state = FactStateInitial;
+            model->fact_text = NULL;
+        },
+        true);
+
+    view_dispatcher_switch_to_view(app->view_dispatcher, view_id);
 }

--- a/callback/flip_library_callback.h
+++ b/callback/flip_library_callback.h
@@ -5,34 +5,55 @@
 
 #define MAX_TOKENS 512 // Adjust based on expected JSON size
 
+typedef enum FactState FactState;
+enum FactState
+{
+    FactStateInitial,
+    FactStateRequested,
+    FactStateReceived,
+    FactStateParsed,
+    FactStateParseError,
+    FactStateError,
+};
+
+typedef enum FlipLibraryCustomEvent FlipLibraryCustomEvent;
+enum FlipLibraryCustomEvent
+{
+    FlipLibraryCustomEventProcess,
+};
+
+typedef struct FactLoaderModel FactLoaderModel;
+typedef bool (*FactLoaderFetch)(FactLoaderModel *model);
+typedef char *(*FactLoaderParser)(FactLoaderModel *model);
+struct FactLoaderModel
+{
+    char *title;
+    char *fact_text;
+    FactState fact_state;
+    FactLoaderFetch fetcher;
+    FactLoaderParser parser;
+    void *parser_context;
+    size_t request_index;
+    size_t request_count;
+    ViewNavigationCallback back_callback;
+    FuriTimer *timer;
+};
+
 extern uint32_t random_facts_index;
 extern bool sent_random_fact_request;
 extern bool random_fact_request_success;
 extern bool random_fact_request_success_all;
 extern char *random_fact;
 
-// Parse JSON to find the "text" key
-char *flip_library_parse_random_fact();
+void flip_library_generic_switch_to_view(FlipLibraryApp *app, char *title, FactLoaderFetch fetcher, FactLoaderParser parser, size_t request_count, ViewNavigationCallback back, uint32_t view_id);
 
-char *flip_library_parse_cat_fact();
+void flip_library_loader_draw_callback(Canvas *canvas, void *model);
 
-char *flip_library_parse_dog_fact();
+void flip_library_loader_init(View *view);
 
-char *flip_library_parse_quote();
+void flip_library_loader_free_model(View *view);
 
-char *flip_library_parse_dictionary();
-
-void flip_library_request_error(Canvas *canvas);
-
-void flip_library_draw_fact(char *message, Widget **widget);
-
-// Callback for drawing the main screen
-void view_draw_callback_random_facts(Canvas *canvas, void *model);
-
-void view_draw_callback_dictionary_run(Canvas *canvas, void *model);
-
-// Input callback for the view (async input handling)
-bool view_input_callback_random_facts(InputEvent *event, void *context);
+bool flip_library_custom_event_callback(void *context, uint32_t index);
 
 void callback_submenu_choices(void *context, uint32_t index);
 
@@ -40,7 +61,7 @@ void text_updated_ssid(void *context);
 
 void text_updated_password(void *context);
 
-void text_updated_dictionary(void *context);
+void text_updated_query(void *context);
 
 uint32_t callback_to_submenu(void *context);
 

--- a/flip_library.c
+++ b/flip_library.c
@@ -2,96 +2,91 @@
 
 FlipLibraryApp *app_instance = NULL;
 
+void flip_library_loader_free_model(View* view);
+
 // Function to free the resources used by FlipLibraryApp
 void flip_library_app_free(FlipLibraryApp *app)
 {
     if (!app)
-    {
-        FURI_LOG_E(TAG, "FlipLibraryApp is NULL");
-        return;
-    }
+        {
+            FURI_LOG_E(TAG, "FlipLibraryApp is NULL");
+            return;
+        }
 
     // Free View(s)
-    if (app->view_random_facts)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewRandomFactsRun);
-        view_free(app->view_random_facts);
-    }
-    if (app->view_dictionary)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewDictionaryRun);
-        view_free(app->view_dictionary);
-    }
+    if (app->view_loader)
+        {
+            view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewLoader);
+            flip_library_loader_free_model(app->view_loader);
+            view_free(app->view_loader);
+        }
 
     // Free Submenu(s)
     if (app->submenu_main)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewSubmenuMain);
-        submenu_free(app->submenu_main);
-    }
+        {
+            view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewSubmenuMain);
+            submenu_free(app->submenu_main);
+        }
     if (app->submenu_random_facts)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewRandomFacts);
-        submenu_free(app->submenu_random_facts);
-    }
+        {
+            view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewRandomFacts);
+            submenu_free(app->submenu_random_facts);
+        }
 
     // Free Widget(s)
-    if (app->widget)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewAbout);
-        widget_free(app->widget);
-    }
-    if (app->widget_random_fact)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewRandomFactWidget);
-        widget_free(app->widget_random_fact);
-    }
-    if (app->widget_dictionary)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewDictionaryWidget);
-        widget_free(app->widget_dictionary);
-    }
+    if (app->widget_about)
+        {
+            view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewAbout);
+            widget_free(app->widget_about);
+        }
+    if (app->widget_result)
+        {
+            view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewWidgetResult);
+            widget_free(app->widget_result);
+        }
 
     // Free Variable Item List(s)
     if (app->variable_item_list_wifi)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewSettings);
-        variable_item_list_free(app->variable_item_list_wifi);
-    }
+        {
+            view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewSettings);
+            variable_item_list_free(app->variable_item_list_wifi);
+        }
 
     // Free Text Input(s)
     if (app->uart_text_input_ssid)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewTextInputSSID);
-        uart_text_input_free(app->uart_text_input_ssid);
-    }
+        {
+            view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewTextInputSSID);
+            uart_text_input_free(app->uart_text_input_ssid);
+        }
     if (app->uart_text_input_password)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewTextInputPassword);
-        uart_text_input_free(app->uart_text_input_password);
-    }
-    if (app->uart_text_input_dictionary)
-    {
-        view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewDictionaryTextInput);
-        uart_text_input_free(app->uart_text_input_dictionary);
-    }
+        {
+            view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewTextInputPassword);
+            uart_text_input_free(app->uart_text_input_password);
+        }
+    if (app->uart_text_input_query)
+        {
+            view_dispatcher_remove_view(app->view_dispatcher, FlipLibraryViewTextInputQuery);
+            uart_text_input_free(app->uart_text_input_query);
+        }
 
     // deinitalize flipper http
     flipper_http_deinit();
 
     // free the view dispatcher
     if (app->view_dispatcher)
-        view_dispatcher_free(app->view_dispatcher);
+        {
+            view_dispatcher_free(app->view_dispatcher);
+        }
 
     // close the gui
     furi_record_close(RECORD_GUI);
 
     if (app_instance)
-    {
-        // free the app instance
-        free(app_instance);
-        app_instance = NULL;
-    }
+        {
+            // free the app instance
+            free(app_instance);
+            app_instance = NULL;
+        }
     // free the app
     free(app);
 }

--- a/flip_library.h
+++ b/flip_library.h
@@ -33,44 +33,32 @@ typedef enum
 typedef enum
 {
     FlipLibraryViewRandomFacts = 7,        // The random facts main screen
-    FlipLibraryViewRandomFactsRun = 8,     // The random facts widget that displays the random fact
-    FlipLibraryViewSubmenuMain = 9,        // The submenu screen
-    FlipLibraryViewAbout = 10,             // The about screen
-    FlipLibraryViewSettings = 11,          // The settings screen
-    FlipLibraryViewTextInputSSID = 12,     // The text input screen (SSID)
-    FlipLibraryViewTextInputPassword = 13, // The text input screen (password)
-    FlipLibraryViewDictionary = 14,        // The dictionary submenu screen
-    //
-    FlipLibraryViewDictionaryTextInput = 15,
-    FlipLibraryViewDictionaryRun = 16,
-    //
-    FlipLibraryViewRandomFactsCats = 17,
-    FlipLibraryViewRandomFactsDogs = 18,
-    FlipLibraryViewRandomFactsQuotes = 19,
-    FlipLibraryViewRandomFactsAll = 20,
-    //
-    FlipLibraryViewRandomFactWidget = 21, // The text box that displays the random fact
-    FlipLibraryViewDictionaryWidget = 22, // The text box that displays the dictionary
+    FlipLibraryViewLoader,                // The loader screen retrieves data from the internet
+    FlipLibraryViewSubmenuMain,           // The submenu screen
+    FlipLibraryViewAbout,                 // The about screen
+    FlipLibraryViewSettings,              // The settings screen
+    FlipLibraryViewTextInputSSID,         // The text input screen (SSID)
+    FlipLibraryViewTextInputPassword,     // The text input screen (password)
+    FlipLibraryViewTextInputQuery,        // Query the user for information
+    FlipLibraryViewWidgetResult,          // The text box that displays the random fact
 } FlipLibraryView;
 
 // Each screen will have its own view
 typedef struct
 {
     ViewDispatcher *view_dispatcher;            // Switches between our views
-    View *view_random_facts;                    // The main screen that displays the random fact
-    View *view_dictionary;                      // The dictionary screen
+    View *view_loader;                          // The screen that loads data from internet
     Submenu *submenu_main;                      // The submenu for the main screen
     Submenu *submenu_random_facts;              // The submenu for the random facts screen
-    Widget *widget;                             // The widget
+    Widget *widget_about;                       // The widget for the about screen
     VariableItemList *variable_item_list_wifi;  // The variable item list (WiFi settings)
     VariableItem *variable_item_ssid;           // The variable item (SSID)
     VariableItem *variable_item_password;       // The variable item (password)
     UART_TextInput *uart_text_input_ssid;       // The text input for the SSID
     UART_TextInput *uart_text_input_password;   // The text input for the password
-    UART_TextInput *uart_text_input_dictionary; // The text input for the dictionary
+    UART_TextInput *uart_text_input_query;      // The text input for querying information
     //
-    Widget *widget_random_fact; // The text box that displays the random fact
-    Widget *widget_dictionary;  // The text box that displays the dictionary
+    Widget *widget_result;      // The text box that displays the result
 
     char *uart_text_input_buffer_ssid;         // Buffer for the text input (SSID)
     char *uart_text_input_temp_buffer_ssid;    // Temporary buffer for the text input (SSID)
@@ -80,9 +68,9 @@ typedef struct
     char *uart_text_input_temp_buffer_password;    // Temporary buffer for the text input (password)
     uint32_t uart_text_input_buffer_size_password; // Size of the text input buffer (password)
 
-    char *uart_text_input_buffer_dictionary;         // Buffer for the text input (dictionary)
-    char *uart_text_input_temp_buffer_dictionary;    // Temporary buffer for the text input (dictionary)
-    uint32_t uart_text_input_buffer_size_dictionary; // Size of the text input buffer (dictionary)
+    char *uart_text_input_buffer_query; // Buffer for the text input (query)
+    char *uart_text_input_temp_buffer_query; // Temporary buffer for the text input (query)
+    uint32_t uart_text_input_buffer_size_query; // Size of the text input buffer (query)
 } FlipLibraryApp;
 
 // Function to free the resources used by FlipLibraryApp


### PR DESCRIPTION
This version uses a 250ms timer to invoke a process callback. The callback determines if we are ready to switch to different states & updates our view's model. The draw function renders data from the model (and the fhttp object).

For each fact we have separate fetch, parse and switch_to_view functions. Hopefully this makes it easier to add new facts in the future without modifying the code for any of the existing facts. For more complex facts, the fetch/parse can use model->request_index to get the current request index (starting at 0) & can store temporary data between requests in a model->parser_context object.
