### PR TITLE
Don't log counter or save wifi on start

### DIFF
--- a/app.c
+++ b/app.c
@@ -30,7 +30,6 @@ int32_t flip_library_app(void *p)
             furi_delay_ms(100);
         }
 
-        FURI_LOG_E(TAG, "Counter: %d", counter);
         if(counter == 0) {
             DialogsApp* dialogs = furi_record_open(RECORD_DIALOGS);
             DialogMessage* message = dialog_message_alloc();

--- a/app.c
+++ b/app.c
@@ -47,13 +47,6 @@ int32_t flip_library_app(void *p)
             dialog_message_free(message);
             furi_record_close(RECORD_DIALOGS);
         }
-
-        // Switch to application wifi settings
-        if(!flipper_http_save_wifi(
-               app_instance->uart_text_input_buffer_ssid,
-               app_instance->uart_text_input_buffer_password)) {
-            FURI_LOG_E(TAG, "Failed to save wifi settings");
-        }
     }
 
     // Run the view dispatcher


### PR DESCRIPTION
Address code-review feedback from @jblanked 
I validated that you can reboot board, then start app and just go to cat facts without issue.